### PR TITLE
Register visualizer as external tool for Results Browser

### DIFF
--- a/add_reg_path.cmd
+++ b/add_reg_path.cmd
@@ -1,2 +1,9 @@
 rem n.b. installer has trailing backslash too. be consistent
 reg add HKLM\Software\Metamorph\OpenMETA-Visualizer /v PATH /d "%~dp0\" /t REG_SZ /f /reg:32
+
+reg add HKLM\SOFTWARE\META\PETBrowser\PETTools\OpenMetaVisualizer /f /ve /d "OpenMETA Visualizer" /reg:32
+reg add HKLM\SOFTWARE\META\PETBrowser\PETTools\OpenMetaVisualizer /f /v "ActionName" /d "Launch in OpenMETA Visualizer" /reg:32
+reg add HKLM\SOFTWARE\META\PETBrowser\PETTools\OpenMetaVisualizer /f /v "ExecutableFilePath" /d "%CD%\Dig\run.cmd" /reg:32
+reg add HKLM\SOFTWARE\META\PETBrowser\PETTools\OpenMetaVisualizer /f /v "ProcessArguments" /d "\"%%1\" \"%CD%\"" /reg:32
+reg add HKLM\SOFTWARE\META\PETBrowser\PETTools\OpenMetaVisualizer /f /v "ShowConsoleWindow" /d "0" /t REG_DWORD /reg:32
+reg add HKLM\SOFTWARE\META\PETBrowser\PETTools\OpenMetaVisualizer /f /v "WorkingDirectory" /d "%%2" /reg:32

--- a/deploy/openmeta-visualizer_x64.wxs
+++ b/deploy/openmeta-visualizer_x64.wxs
@@ -83,6 +83,16 @@
           <RegistryValue Name='VCSHASH' Type='string' Value='$(var.VCSHASH)'/>
         </RegistryKey>
       </Component>
+      <Component Id='reg_PETBROWSER' Guid='{094b0ccf-de16-4167-932d-42293fa20d6e}' Win64='no'>
+        <RegistryKey Root='HKLM' Key='Software\META\PETBrowser\PETTools\OpenMetaVisualizer'>
+          <RegistryValue Type='string' Value='OpenMETA Visualizer'/>
+          <RegistryValue Name='ActionName' Type='string' Value='Launch in OpenMETA Visualizer'/>
+          <RegistryValue Name='ExecutableFilePath' Type='string' Value='[INSTALLDIR]\Dig\run.cmd'/>
+          <RegistryValue Name='ProcessArguments' Type='string' Value='"%1" "[INSTALLDIR]"'/>
+          <RegistryValue Name='WorkingDirectory' Type='string' Value='%2'/>
+          <RegistryValue Name='ShowConsoleWindow' Type='integer' Value='0'/>
+        </RegistryKey>
+      </Component>
     </DirectoryRef>
     <DirectoryRef Id="dir_Dig_www">
         <Directory Id="SurrogateModeling" Name="SurrogateModeling" />
@@ -99,6 +109,7 @@
       <ComponentRef Id='reg_PATH' />
       <ComponentRef Id='reg_VERSIONSTR' />
       <ComponentRef Id='reg_VCSHASH' />
+      <ComponentRef Id='reg_PETBROWSER' />
     </Feature>
 
     <!-- =========================================================== -->


### PR DESCRIPTION
This registers the visualizer as an external tool for the Results Browser, as a prerequisite for OPENMETA-315 (external visualization tool support in the Results Browser).